### PR TITLE
Include test.todo in skipped count

### DIFF
--- a/jest-simple-dot-reporter.js
+++ b/jest-simple-dot-reporter.js
@@ -17,6 +17,7 @@ class JestSimpleDotReporter {
         const {
             numFailedTests,
             numPassedTests,
+            numTodoTests,
             numPendingTests,
             testResults,
             numTotalTests,
@@ -41,7 +42,7 @@ class JestSimpleDotReporter {
         console.log(`Ran ${numTotalTests} tests in ${testDuration()}`);
         process.stdout.write(` ${numPassedTests || 0} passing`);
         process.stdout.write(` ${numFailedTests || 0} failing`);
-        process.stdout.write(` ${numPendingTests || 0} pending`);
+        process.stdout.write(` ${(numTodoTests || 0) + (numPendingTests || 0)} skipped`);
         console.log();
 
         function testDuration() {
@@ -55,12 +56,19 @@ class JestSimpleDotReporter {
 
     onTestResult(test, testResult) {
         for (var i = 0; i < testResult.testResults.length; i++) {
-            if (testResult.testResults[i].status === 'passed') {
-                process.stdout.write('.');
-            } else if (testResult.testResults[i].status === 'pending') {
-                process.stdout.write('*');
-            } else {
-                process.stdout.write('F');
+            switch (testResult.testResults[i].status) {
+                case "passed":
+                    process.stdout.write('.');
+                    break;
+                case "pending":
+                case "todo":
+                    process.stdout.write('*');
+                    break;
+                case "failed":
+                    process.stdout.write('F');
+                    break;
+                default:
+                    process.stdout.write(`(${testResult.testResults[i].status})`);
             }
         }
 

--- a/jest-simple-dot-reporter.js
+++ b/jest-simple-dot-reporter.js
@@ -55,22 +55,24 @@ class JestSimpleDotReporter {
     }
 
     onTestResult(test, testResult) {
-        for (var i = 0; i < testResult.testResults.length; i++) {
-            switch (testResult.testResults[i].status) {
-                case "passed":
-                    process.stdout.write('.');
-                    break;
-                case "pending":
-                case "todo":
-                    process.stdout.write('*');
-                    break;
-                case "failed":
-                    process.stdout.write('F');
-                    break;
-                default:
-                    process.stdout.write(`(${testResult.testResults[i].status})`);
+            for (var i = 0; i < testResult.testResults.length; i++) {
+                switch (testResult.testResults[i].status) {
+                    case "passed":
+                        process.stdout.write(".")
+                        break
+                    case "skipped":
+                    case "pending":
+                    case "todo":
+                    case "disabled":
+                        process.stdout.write("*")
+                        break
+                    case "failed":
+                        process.stdout.write("F")
+                        break
+                    default:
+                        process.stdout.write(`(${testResult.testResults[i].status})`)
+                }
             }
-        }
 
         if (!--this._numTestSuitesLeft && this._globalConfig.collectCoverage) {
             console.log()


### PR DESCRIPTION
Hi 👋

Thanks for this reporter - it's just what I needed!

I noticed that tests labelled with `test.todo()` were shown in the dots as `F` and weren't being counted in the summary at the end. I've added support for them in this PR, showing them like pending tests (`*`).

Let me know what you think!