### PR TITLE
break lines for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For example, create a `jest.config.js` file containing:
 module.exports = {
   "verbose": false,
   "reporters": [
-    ["jest-simple-dot-reporter", {"color": true}]
+    ["jest-simple-dot-reporter", {"color": true, "maxLength": 120}]
   ]
 };
 ```

--- a/jest-simple-dot-reporter.js
+++ b/jest-simple-dot-reporter.js
@@ -4,10 +4,11 @@ class JestSimpleDotReporter {
     constructor(globalConfig, options) {
         this._globalConfig = globalConfig;
         this._options = options;
+        this._counter = 0;
     }
 
     onRunStart(test) {
-        this._numTestSuitesLeft = test.numTotalTestSuites; 
+        this._numTestSuitesLeft = test.numTotalTestSuites;
 
         console.log()
         console.log(`Found ${test.numTotalTestSuites} test suites`);
@@ -55,24 +56,29 @@ class JestSimpleDotReporter {
     }
 
     onTestResult(test, testResult) {
-            for (var i = 0; i < testResult.testResults.length; i++) {
-                switch (testResult.testResults[i].status) {
-                    case "passed":
-                        process.stdout.write(".")
-                        break
-                    case "skipped":
-                    case "pending":
-                    case "todo":
-                    case "disabled":
-                        process.stdout.write("*")
-                        break
-                    case "failed":
-                        process.stdout.write("F")
-                        break
-                    default:
-                        process.stdout.write(`(${testResult.testResults[i].status})`)
-                }
+        for (var i = 0; i < testResult.testResults.length; i++) {
+            switch (testResult.testResults[i].status) {
+                case "passed":
+                    process.stdout.write(".")
+                    break
+                case "skipped":
+                case "pending":
+                case "todo":
+                case "disabled":
+                    process.stdout.write("*")
+                    break
+                case "failed":
+                    process.stdout.write("F")
+                    break
+                default:
+                    process.stdout.write(`(${testResult.testResults[i].status})`)
             }
+
+            this._counter++;
+            if (this._options.maxLength && this._counter % this._options.maxLength === 0) {
+                process.stdout.write("\n")
+            }
+        }
 
         if (!--this._numTestSuitesLeft && this._globalConfig.collectCoverage) {
             console.log()


### PR DESCRIPTION
Some of CI tools doesn't soft wrap terminal output so it would be great to have opportunity to force break lines.

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/1397054/211034551-74bd477c-d43b-4409-bd67-9014a175f5b4.png">
